### PR TITLE
Fix frame calculation when DF every 10 minutes

### DIFF
--- a/lib/timecode.rb
+++ b/lib/timecode.rb
@@ -209,7 +209,7 @@ class Timecode
     def at(hrs, mins, secs, frames, with_fps = DEFAULT_FPS, drop_frame = false)
       validate_atoms!(hrs, mins, secs, frames, with_fps)
       comp = ComputationValues.new(with_fps, drop_frame)
-      if drop_frame && secs == 0 && (mins % 10) && (frames < comp.drop_count)
+      if drop_frame && secs == 0 && (mins % 10 > 0) && (frames < comp.drop_count)
         frames = comp.drop_count
       end
       

--- a/test/test_timecode.rb
+++ b/test/test_timecode.rb
@@ -615,6 +615,10 @@ describe "Timecode.parse should" do
   it "properly handle 09 and 08 as part of complete TC pattern" do
     Timecode.parse( "09:08:09:08", 25).total.must_equal 822233
   end
+
+  it "properly handle 10 minute DF timecode" do
+    Timecode.parse( "00:10:00;00", 29.97).total.must_equal 17982
+  end
 end
 
 describe "Timecode.soft_parse should" do


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/guerilla-di/timecode/issues/8#issuecomment-326733932 .

When in DF mode with 29.97 FPS we should drop 2 frames every minute for the first 9 of each group of 10 minutes.

A video which lasts 10 minutes (600 seconds) at 30 FPS would have 18,000 frames.
The same video at 29.97 (30000/1001) FPS without drop frames would have 17,982 frames.
To stay in sync we would need to drop (18,000 - 17.982) frames, that is 18 frames every 10 minutes, or 2 frames per minutes for the first 9 minutes then 0 frames on the 10th minute.
