### PR TITLE
fix!: handle non integer frame rates adequately 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Text Editor configuration.
+#
+# See http://editorconfig.org for details and a complete list of supported
+# platforms.
+
+# This file is read top to bottom;
+# the most recent rules found take precedence.
+
+root = true
+
+[{*.{editorconfig,rb},Rakefile}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.rdoc
+++ b/README.rdoc
@@ -9,13 +9,13 @@ Value class for SMPTE timecode information
 == SYNOPSIS:
 
   tc = Timecode.parse("00:00:10:12", fps = 25)
-  tc.total #=> 262
+  tc.total #=> 262.0
   
   Drop frame
   tc = Timecode.parse("00:00:10;12", fps = 29.97)
   
-  plus_ten = tc + Timecode.parse("10h", fps = 25)
-  plus_ten #=> "10:00:10:12"
+  plus_ten = tc + Timecode.from_seconds(10 * 36000, fps = 29.97, true)
+  plus_ten #=> #<Timecode:100:00:10:12 (10789512F@29.97)>
 
 == INSTALL:
 

--- a/lib/timecode.rb
+++ b/lib/timecode.rb
@@ -13,12 +13,11 @@
 require "approximately"
 require File.dirname(__FILE__) + '/timecode/version'
 class Timecode
-  
+
   class ComputationValues
     attr_reader :drop_count, :frames_per_min, :frames_per_10_min, :frames_per_hour, :nd_frames_per_min
-    
+
     def initialize(fps, drop_frame)
-      rounded_base = fps.round
       if (drop_frame)
         # first 2 frame numbers shall be omitted at the start of each minute,
         # except minutes 0, 10, 20, 30, 40 and 50
@@ -27,15 +26,17 @@ class Timecode
           @drop_count *= 2
         end
 
-        @frames_per_min = rounded_base * 60 - @drop_count
+        fps = fps.round
+
+        @frames_per_min = fps * 60 - @drop_count
         @frames_per_10_min = @frames_per_min * 10 + @drop_count
       else
-        @frames_per_min = rounded_base * 60
+        @frames_per_min = fps * 60
         @frames_per_10_min = @frames_per_min * 10
       end
 
       @frames_per_hour = @frames_per_10_min * 6
-      @nd_frames_per_min = rounded_base * 60
+      @nd_frames_per_min = fps * 60
     end
   end
 
@@ -85,20 +86,23 @@ class Timecode
 
   # Gets raised when you try to compute two timecodes with different framerates together
   class WrongFramerate < ArgumentError; end
-  
+
   # Gets raised when you try to compute two timecodes with different drop frame flag together
   class WrongDropFlag < ArgumentError; end
 
-  # Initialize a new Timecode object with a certain amount of frames, a framerate and an optional drop frame flag 
+  # Initialize a new Timecode object with a certain amount of frames, a framerate and an optional drop frame flag
   # will be interpreted as the total number of frames
   def initialize(total = 0, fps = DEFAULT_FPS, drop_frame = false)
-    raise WrongFramerate, "FPS cannot be zero" if fps.zero?
-    self.class.check_framerate!(fps)
-    # If total is a string, use parse
-    raise RangeError, "Timecode cannot be negative" if total.to_i < 0
-    # Always cast framerate to float, and num of frames to integer
-    @total, @fps = total.to_i, fps.to_f
     @drop_frame = drop_frame
+    # Always cast framerate to float
+    @fps = fps.to_f
+    # Cast num of frames to integer or to float
+    @total = drop_frame ? total.to_i : total.to_f
+
+    raise WrongFramerate, "FPS cannot be zero" if @fps.zero?
+    self.class.check_framerate!(@fps)
+    # If total is a string, use parse
+    raise RangeError, "Timecode cannot be negative" if @total < 0
     @value = validate!
     freeze
   end
@@ -146,7 +150,7 @@ class Timecode
     # Parses the timecode contained in a passed filename as frame number in a sequence
     def from_filename_in_sequence(filename_with_or_without_path, fps = DEFAULT_FPS)
       b = File.basename(filename_with_or_without_path)
-      number = b.scan(/\d+/).flatten[-1].to_i
+      number = b.scan(/\d+/).flatten[-1]
       new(number, fps)
     end
 
@@ -155,7 +159,7 @@ class Timecode
     # * 10h 20m 10s 1f (or any combination thereof) - will be disassembled to hours, frames, seconds and so on automatically
     # * 123 - will be parsed as 00:00:01:23
     # * 00:00:00:00 - will be parsed as zero TC
-    def parse(spaced_input, with_fps = DEFAULT_FPS)
+    def parse(spaced_input, with_fps = DEFAULT_FPS, allow_inaccurate = true)
       input = spaced_input.strip
 
       # 00:00:00;00
@@ -172,10 +176,10 @@ class Timecode
         return at(*atoms_and_fps)
       # 00:00:00.0
       elsif input =~ FRACTIONAL_TC_RE
-        parse_with_fractional_seconds(input, with_fps)
+        parse_with_fractional_seconds(input, with_fps, allow_inaccurate)
       # 00:00:00:000
       elsif input =~ TICKS_TC_RE
-        parse_with_ticks(input, with_fps)
+        parse_with_ticks(input, with_fps, allow_inaccurate)
       # 10h 20m 10s 1f 00:00:00:01 - space separated is a sum of parts
       elsif input =~ /\s/
         parts = input.gsub(/\s/, ' ').split.reject{|e| e.strip.empty? }
@@ -212,17 +216,18 @@ class Timecode
       if drop_frame && secs == 0 && (mins % 10 > 0) && (frames < comp.drop_count)
         frames = comp.drop_count
       end
-      
-      total = hrs * comp.frames_per_hour
+
       if drop_frame
+        total = hrs * comp.frames_per_hour
         total += (mins / 10) * comp.frames_per_10_min
         total += (mins % 10) * comp.frames_per_min
+        rounded_base = with_fps.round
+        total += secs * rounded_base
+        total += frames
       else
-        total += mins * comp.frames_per_min
+        total = (hrs * 3600 + mins * 60 + secs) * with_fps + frames
       end
-      rounded_base = with_fps.round
-      total += secs * rounded_base
-      total += frames
+
       new(total, with_fps, drop_frame)
     end
 
@@ -242,12 +247,20 @@ class Timecode
 
     # Parse a timecode with fractional seconds instead of frames. This is how ffmpeg reports
     # a timecode
-    def parse_with_fractional_seconds(tc_with_fractions_of_second, fps = DEFAULT_FPS)
+    def parse_with_fractional_seconds(tc_with_fractions_of_second, fps = DEFAULT_FPS, allow_inaccurate = true)
       fraction_expr = /[\.,](\d+)$/
       fraction_part = ('.' + tc_with_fractions_of_second.scan(fraction_expr)[0][0]).to_f
 
       seconds_per_frame = 1.0 / fps.to_f
-      frame_idx = (fraction_part / seconds_per_frame).floor
+      frame_idx = fraction_part / seconds_per_frame
+
+      if frame_idx.floor != frame_idx
+        if allow_inaccurate
+          frame_idx = frame_idx.floor
+        else
+          raise CannotParse, "'#{fraction_part}' isn't supported since at this frame rate '#{fps}' it doesn't give an integer for the number of frames"
+        end
+      end
 
       tc_with_frameno = tc_with_fractions_of_second.gsub(fraction_expr, ":%02d" % frame_idx)
 
@@ -257,14 +270,23 @@ class Timecode
     # Parse a timecode with ticks of a second instead of frames. A 'tick' is defined as
     # 4 msec and has a range of 0 to 249. This format can show up in subtitle files for digital cinema
     # used by CineCanvas systems
-    def parse_with_ticks(tc_with_ticks, fps = DEFAULT_FPS)
+    def parse_with_ticks(tc_with_ticks, fps = DEFAULT_FPS, allow_inaccurate = true)
       ticks_expr = /(\d{3})$/
       num_ticks = tc_with_ticks.scan(ticks_expr).join.to_i
 
       raise RangeError, "Invalid tick count #{num_ticks}" if num_ticks > 249
 
       seconds_per_frame = 1.0 / fps
-      frame_idx = ( (num_ticks * 0.004) / seconds_per_frame ).floor
+      frame_idx = (num_ticks * 0.004) / seconds_per_frame
+
+      if frame_idx.floor != frame_idx
+        if allow_inaccurate
+          frame_idx = frame_idx.floor
+        else
+          raise CannotParse, "'#{num_ticks}' isn't supported since at this frame rate '#{fps}' it doesn't give an integer for the number of frames"
+        end
+      end
+
       tc_with_frameno = tc_with_ticks.gsub(ticks_expr, "%02d" % frame_idx)
 
       parse(tc_with_frameno, fps)
@@ -273,7 +295,10 @@ class Timecode
     # create a timecode from the number of seconds. This is how current time is supplied by
     # QuickTime and other systems which have non-frame-based timescales
     def from_seconds(seconds_float, the_fps = DEFAULT_FPS, drop_frame = false)
-      total_frames = (seconds_float.to_f * the_fps.to_f).round.to_i
+      total_frames = seconds_float.to_f * the_fps.to_f
+      if drop_frame
+        total_frames = total_frames.round.to_i
+      end
       new(total_frames, the_fps, drop_frame)
     end
 
@@ -312,7 +337,7 @@ class Timecode
   def total
     to_f
   end
-  
+
   # get DF
   def drop?
     @drop_frame
@@ -376,14 +401,14 @@ class Timecode
   def to_s
     vs = value_parts
     vs[0] = vs[0] % 100 # Rollover any values > 99
-    (@drop_frame ? WITH_FRAMES_DF : WITH_FRAMES) % vs 
+    (@drop_frame ? WITH_FRAMES_DF : WITH_FRAMES) % vs
   end
-  
+
   # Get formatted SMPTE timecode. Hours might be larger than 99 and will not roll over
   def to_s_without_rollover
     WITH_FRAMES % value_parts
   end
-  
+
   # get total frames as float
   def to_f
     @total
@@ -391,7 +416,7 @@ class Timecode
 
   # get total frames as integer
   def to_i
-    @total
+    @total.to_i
   end
 
   # add number of frames (or another timecode) to this one
@@ -403,7 +428,7 @@ class Timecode
         raise WrongDropFlag, "You are calculating timecodes with different drop flag values"
       else
         raise WrongFramerate, "You are calculating timecodes with different framerates"
-      end      
+      end
     else
       self.class.new(@total + arg, @fps, @drop_frame)
     end
@@ -417,14 +442,14 @@ class Timecode
 
   # Subtract a number of frames
   def -(arg)
-    if (arg.is_a?(Timecode) &&  framerate_in_delta(arg.fps, @fps) && (arg.drop? == @drop_frame))
+    if (arg.is_a?(Timecode) && framerate_in_delta(arg.fps, @fps) && (arg.drop? == @drop_frame))
       self.class.new(@total-arg.total, @fps, @drop_frame)
     elsif (arg.is_a?(Timecode))
       if (arg.drop? != @drop_frame)
         raise WrongDropFlag, "You are calculating timecodes with different drop flag values"
       else
         raise WrongFramerate, "You are calculating timecodes with different framerates"
-      end      
+      end
     else
       self.class.new(@total-arg, @fps, @drop_frame)
     end
@@ -484,30 +509,37 @@ class Timecode
   # Prepare and format the values for TC output
   def validate!
     comp = ComputationValues.new(@fps, @drop_frame)
-    
+
     frames_dropped = false
     temp_total = @total
     hrs = (temp_total / comp.frames_per_hour).floor
-    
+
     temp_total %= comp.frames_per_hour
     mins = (temp_total / comp.frames_per_10_min * 10).floor
-    
+
     temp_total %= comp.frames_per_10_min
     if (temp_total >= comp.nd_frames_per_min)
       temp_total -= comp.nd_frames_per_min
-      mins += ((temp_total / comp.frames_per_min) + 1).floor
+      if @drop_frame
+        mins += ((temp_total / comp.frames_per_min) + 1).floor
+      end
       temp_total %= comp.frames_per_min
       frames_dropped = @drop_frame
     end
-    
-    rounded_base = @fps.round
-    secs = (temp_total / rounded_base).floor
-    rest_frames = (temp_total % rounded_base).floor
-    
+
+    fps = @drop_frame ? @fps.round : @fps
+
+    secs = (temp_total / fps).floor
+    rest_frames = temp_total % fps
+
+    if @drop_frames
+      rest_frames = rest_frames.floor
+    end
+
     if frames_dropped
       rest_frames += comp.drop_count
-      if rest_frames >= rounded_base
-        rest_frames -= rounded_base
+      if rest_frames >= fps
+        rest_frames -= fps
         secs += 1
         if secs >= 60
           secs = 0
@@ -521,7 +553,7 @@ class Timecode
           end
         end
       end
-    end   
+    end
 
     self.class.validate_atoms!(hrs, mins, secs, rest_frames, @fps)
 

--- a/lib/timecode/version.rb
+++ b/lib/timecode/version.rb
@@ -1,3 +1,3 @@
 class Timecode
-  VERSION = '2.2.3'
+  VERSION = '3.0.0'
 end

--- a/test/test_timecode.rb
+++ b/test/test_timecode.rb
@@ -659,6 +659,25 @@ describe "Timecode.parse should" do
 
   it "properly handle non integer fps" do
     _(Timecode.parse( "15:25:13:01", 24000.0/1001.0).total).must_be_within_delta 1330982, 0.02
+    _((Timecode.parse( "15:25:13:00", 24000.0/1001.0) + Timecode.at(0, 0, 0, 0.981, 24000.0/1001.0)).total).must_be_within_delta 1330982, 0.0001
+    _(Timecode.parse( "15:25:13:01", 30000.0/1001.0).total).must_be_within_delta 1663727, 0.28
+    _((Timecode.parse( "15:25:13:00", 30000.0/1001.0) + Timecode.at(0, 0, 0, 0.7263, 30000.0/1001.0)).total).must_be_within_delta 1663727, 0.0001
+    _(Timecode.parse( "15:25:13:01", 60000.0/1001.0).total).must_be_within_delta 3327453, 0.55
+    _((Timecode.parse( "15:25:13:00", 60000.0/1001.0) + Timecode.at(0, 0, 0, 0.45255, 60000.0/1001.0)).total).must_be_within_delta 3327453, 0.0001
+
+    _(Timecode.parse( "00:25:13:01", 24000.0/1001.0).total).must_be_within_delta 36276, 0.73
+    _((Timecode.parse( "00:25:13:00", 24000.0/1001.0) + Timecode.at(0, 0, 0, 0.2757, 24000.0/1001.0)).total).must_be_within_delta 36276, 0.0001
+    _(Timecode.parse( "00:25:13:01", 30000.0/1001.0).total).must_be_within_delta 45345, 0.66
+    _((Timecode.parse( "00:25:13:00", 30000.0/1001.0) + Timecode.at(0, 0, 0, 0.34466, 30000.0/1001.0)).total).must_be_within_delta 45345, 0.0001
+    _(Timecode.parse( "00:25:13:01", 60000.0/1001.0).total).must_be_within_delta 90690, 0.32
+    _((Timecode.parse( "00:25:13:00", 60000.0/1001.0) + Timecode.at(0, 0, 0, 0.6893, 60000.0/1001.0)).total).must_be_within_delta 90690, 0.0001
+
+    _(Timecode.parse( "00:00:13:01", 24000.0/1001.0).total).must_be_within_delta 312, 0.69
+    _((Timecode.parse( "00:00:13:00", 24000.0/1001.0) + Timecode.at(0, 0, 0, 0.3117, 24000.0/1001.0)).total).must_be_within_delta 312, 0.0001
+    _(Timecode.parse( "00:00:13:01", 30000.0/1001.0).total).must_be_within_delta 390, 0.62
+    _((Timecode.parse( "00:00:13:00", 30000.0/1001.0) + Timecode.at(0, 0, 0, 0.3896, 30000.0/1001.0)).total).must_be_within_delta 390, 0.0001
+    _(Timecode.parse( "00:00:13:01", 60000.0/1001.0).total).must_be_within_delta 780, 0.23
+    _((Timecode.parse( "00:00:13:00", 60000.0/1001.0) + Timecode.at(0, 0, 0, 0.7792, 60000.0/1001.0)).total).must_be_within_delta 780, 0.0001
   end
 end
 

--- a/test/test_timecode.rb
+++ b/test/test_timecode.rb
@@ -42,7 +42,8 @@ describe "Timecode.new should" do
   end
 
   it 'calculates seconds correctly for rational fps' do
-    _(Timecode.new(548999, 23.976).seconds).must_equal 14
+    _(Timecode.new(548999, 24).seconds).must_equal 14
+    _(Timecode.new(548999, 23.976).seconds).must_equal 37
     _(Timecode.new(9662, 29.97, true).seconds).must_equal 22
     _(Timecode.new(1078920, 29.97, true).seconds).must_equal 0
   end
@@ -235,12 +236,12 @@ describe "Timecode#to_seconds should" do
   it "properly roundtrip a value via Timecode.from_seconds" do
     secs_in = 19.76
     from_secs = Timecode.from_seconds(secs_in, 25.0)
-    _(from_secs.total).must_equal 494
+    _(from_secs.total).must_be_within_delta 494, 0.001
     _(from_secs.to_seconds).must_be_within_delta secs_in, 0.001
 
     secs_in = 15603.50
     from_secs = Timecode.from_seconds(secs_in, 29.97, true)
-    _(from_secs.total).must_equal 467637
+    _(from_secs.total).must_be_within_delta 467637, 0.001
     _(from_secs.to_seconds).must_be_within_delta secs_in, 0.005
   end
 end
@@ -257,7 +258,11 @@ describe "An existing Timecode on inspection should" do
 
   it "properly print itself with DF" do
     _(Timecode.new(9662, 29.97, true).to_s).must_equal "00:05:22;12"
-    _(Timecode.new(9662, 29.97, false).to_s).must_equal "00:05:22:02"
+    # 9662 frames at 29.97 fps:
+    # (9662 / (60 * 29.97)).floor = 5min
+    # ((9662 % (60 * 29.97)) / 29.97).floor = 22
+    # (9662 % (60 * 29.97)) % 29.97 = 11.6600...
+    _(Timecode.new(9662, 29.97, false).to_s).must_equal "00:05:22:11"
   end
 end
 
@@ -290,7 +295,8 @@ describe "A Timecode on conversion should" do
     _(at24.total).must_equal 1800
     at29 = tc.convert(29.97)
     _(at29.total).must_equal 1800
-    _(at29.to_s).must_equal "00:01:00:00"
+    # 1800 frames at 29.97 frames per second (no frames dropped) => 1800/29.97 = 60.06sec = 60sec + (1800.0 / 29.97 - 60) * 29.97 frames = 60sec + 1.8 frames
+    _(at29.to_s).must_equal "00:01:00:01"
     at29DF = tc.convert(29.97, true)
     _(at29DF.total).must_equal 1800
     _(at29DF.to_s).must_equal "00:01:00;02"
@@ -301,7 +307,8 @@ describe "A Timecode on conversion should" do
     _(at29.to_s).must_equal "00:01:00;02"
     at29ND = tc1.convert(29.97, false)
     _(at29ND.total).must_equal 1800
-    _(at29ND.to_s).must_equal "00:01:00:00"
+    # 1800 frames at 29.97 frames per second (no frames dropped) => 1800/29.97 = 60.06sec = 60sec + (1800.0 / 29.97 - 60) * 29.97 frames = 60sec + 1.8 frames
+    _(at29ND.to_s).must_equal "00:01:00:01"
   end
 end
 
@@ -587,18 +594,50 @@ describe "Timecode.parse should" do
     tc = Timecode.parse_with_fractional_seconds(fraction, 10)
     _(tc.to_s).must_equal "00:00:07:05"
 
-    fraction = "00:00:07.04"
+    fraction = "00:00:07.08"
     tc = Timecode.parse_with_fractional_seconds(fraction, 12.5)
-    _(tc.to_s).must_equal "00:00:07:00"
+    _(tc.to_s).must_equal "00:00:07:01"
 
     fraction = "00:00:07.16"
     tc = Timecode.parse_with_fractional_seconds(fraction, 12.5)
     _(tc.to_s).must_equal "00:00:07:02"
   end
 
+  it "parse timecode with ticks of a second instead of frames" do
+    tc_with_ticks = "00:00:07:001"
+    tc = Timecode.parse_with_ticks(tc_with_ticks, 10)
+    _(tc.to_s).must_equal "00:00:07:00"
+
+    tc_with_ticks = "00:00:07:050"
+    tc = Timecode.parse_with_ticks(tc_with_ticks, 10)
+    _(tc.to_s).must_equal "00:00:07:02"
+
+    tc_with_ticks = "00:00:07:149"
+    tc = Timecode.parse_with_ticks(tc_with_ticks, 12.5)
+    _(tc.to_s).must_equal "00:00:07:07"
+
+    tc_with_ticks = "00:00:07:217"
+    tc = Timecode.parse_with_ticks(tc_with_ticks, 12.5)
+    _(tc.to_s).must_equal "00:00:07:10"
+  end
+
   it "reports DF timecode" do
     df_tc = "00:00:00;01"
     _(Timecode.parse(df_tc, 29.97).drop?).must_equal true
+  end
+
+  it "raise on unsupported fraction of seconds" do
+    fraction = "00:00:07.149"
+    _(lambda { Timecode.parse_with_fractional_seconds(fraction, 12.5, false) }).must_raise Timecode::CannotParse
+    tc = Timecode.parse_with_fractional_seconds(fraction, 12.5, true)
+    _(tc.to_s).must_equal "00:00:07:01"
+  end
+
+  it "raise on unsupported ticks of a second" do
+    tc_with_ticks = "00:00:07.050"
+    _(lambda { Timecode.parse_with_ticks(tc_with_ticks, 12.5, false) }).must_raise Timecode::CannotParse
+    tc = Timecode.parse_with_ticks(tc_with_ticks, 12.5, true)
+    _(tc.to_s).must_equal "00:00:07:00"
   end
 
   it "raise on improper format" do
@@ -618,12 +657,7 @@ describe "Timecode.parse should" do
     _(Timecode.parse( "00:10:00;00", 29.97).total).must_equal 17982
   end
 
-  it "handle non integer fps without being accurate" do
-    _(Timecode.parse( "15:25:13:01", 24000.0/1001.0).total).must_equal 1332313
-  end
-
   it "properly handle non integer fps" do
-    skip "non integer fps aren't not handled properly - this test fails whereas it should pass"
     _(Timecode.parse( "15:25:13:01", 24000.0/1001.0).total).must_be_within_delta 1330982, 0.02
   end
 end

--- a/test/test_timecode.rb
+++ b/test/test_timecode.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec' # must be after "require 'minitest/autorun'" to avoid a 'circular require considered harmful' warning
 
 require File.expand_path(File.dirname(__FILE__)) + '/../lib/timecode'
 
@@ -16,45 +16,45 @@ describe "Timecode.new should" do
 
   it "instantiate from int" do
     tc = Timecode.new(10)
-    tc.must_be_kind_of Timecode
-    tc.total.must_equal 10
+    _(tc).must_be_kind_of Timecode
+    _(tc.total).must_equal 10
   end
 
   it "always coerce FPS to float" do
-    Timecode.new(10, 24).fps.must_be_kind_of(Float)
-    Timecode.new(10, 25.0).fps.must_be_kind_of(Float)
-    Timecode.new(10, 29.97).fps.must_be_kind_of(Float)
-    Timecode.new(10, 59.94).fps.must_be_kind_of(Float)
+    _(Timecode.new(10, 24).fps).must_be_kind_of(Float)
+    _(Timecode.new(10, 25.0).fps).must_be_kind_of(Float)
+    _(Timecode.new(10, 29.97).fps).must_be_kind_of(Float)
+    _(Timecode.new(10, 59.94).fps).must_be_kind_of(Float)
   end
 
   it "create a zero TC with no arguments" do
-    Timecode.new.must_equal Timecode.new(0)
+    _(Timecode.new).must_equal Timecode.new(0)
   end
 
   it "accept full string SMPTE timecode as well" do
-    Timecode.new("00:25:30:10", 25).must_equal Timecode.parse("00:25:30:10")
+    _(Timecode.new("00:25:30:10", 25)).must_equal Timecode.parse("00:25:30:10")
   end
 
   it 'calculates correctly (spot check with special values)' do
-    lambda{ Timecode.new 496159, 23.976 }.must_be_silent
-    lambda{ Timecode.new 548999, 23.976 }.must_be_silent
-    lambda{ Timecode.new 9662, 29.97 }.must_be_silent
+    _(lambda{ Timecode.new 496159, 23.976 }).must_be_silent
+    _(lambda{ Timecode.new 548999, 23.976 }).must_be_silent
+    _(lambda{ Timecode.new 9662, 29.97 }).must_be_silent
   end
 
   it 'calculates seconds correctly for rational fps' do
-    Timecode.new(548999, 23.976).seconds.must_equal 14
-    Timecode.new(9662, 29.97, true).seconds.must_equal 22
-    Timecode.new(1078920, 29.97, true).seconds.must_equal 0
+    _(Timecode.new(548999, 23.976).seconds).must_equal 14
+    _(Timecode.new(9662, 29.97, true).seconds).must_equal 22
+    _(Timecode.new(1078920, 29.97, true).seconds).must_equal 0
   end
-  
+
   it 'calculates timecode correctly for rational fps' do
     atoms_ok = lambda { |tc, h, m, s, f|
-        tc.hours.must_equal h
-        tc.minutes.must_equal m
-        tc.seconds.must_equal s
-        tc.frames.must_equal f
+        _(tc.hours).must_equal h
+        _(tc.minutes).must_equal m
+        _(tc.seconds).must_equal s
+        _(tc.frames).must_equal f
       }
-    
+
     atoms_ok.call(Timecode.new(9662, 29.97, true), 0, 5, 22, 12)
     atoms_ok.call(Timecode.new(467637, 29.97, true), 4, 20, 3, 15)
     atoms_ok.call(Timecode.new(1078920, 29.97, true), 10, 0, 0, 0)
@@ -64,50 +64,50 @@ end
 describe "Timecode.validate_atoms! should" do
 
   it "disallow more than 999 hrs" do
-    lambda{ Timecode.validate_atoms!(999,0,0,0, 25) }.must_be_silent
-    lambda{ Timecode.validate_atoms!(1000,0,0,0, 25) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.validate_atoms!(999,0,0,0, 25) }).must_be_silent
+    _(lambda{ Timecode.validate_atoms!(1000,0,0,0, 25) }).must_raise(Timecode::RangeError)
   end
 
   it "disallow more than 59 minutes" do
-    lambda{ Timecode.validate_atoms!(1,60,0,0, 25) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.validate_atoms!(1,60,0,0, 25) }).must_raise(Timecode::RangeError)
   end
 
   it "disallow more than 59 seconds" do
-    lambda{ Timecode.validate_atoms!(1,0,60,0, 25) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.validate_atoms!(1,0,60,0, 25) }).must_raise(Timecode::RangeError)
   end
 
   it "disallow more frames than what the framerate permits" do
-    lambda{ Timecode.validate_atoms!(1,0,45,25, 25) }.must_raise(Timecode::RangeError)
-    lambda{ Timecode.validate_atoms!(1,0,45,32, 30) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.validate_atoms!(1,0,45,25, 25) }).must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.validate_atoms!(1,0,45,32, 30) }).must_raise(Timecode::RangeError)
   end
 
   it "pass validation with usable values" do
-    lambda{ Timecode.validate_atoms!(20, 20, 10, 5, 25)}.must_be_silent
+    _(lambda{ Timecode.validate_atoms!(20, 20, 10, 5, 25)}).must_be_silent
   end
 end
 
 describe "Timecode.at should" do
 
   it "disallow more than 999 hrs" do
-    lambda{ Timecode.at(999,0,0,0) }.must_be_silent
-    lambda{ Timecode.at(1000,0,0,0) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.at(999,0,0,0) }).must_be_silent
+    _(lambda{ Timecode.at(1000,0,0,0) }).must_raise(Timecode::RangeError)
   end
 
   it "disallow more than 59 minutes" do
-    lambda{ Timecode.at(1,60,0,0) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.at(1,60,0,0) }).must_raise(Timecode::RangeError)
   end
 
   it "disallow more than 59 seconds" do
-    lambda{ Timecode.at(1,0,60,0) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.at(1,0,60,0) }).must_raise(Timecode::RangeError)
   end
 
   it "disallow more frames than what the framerate permits" do
-    lambda{ Timecode.at(1,0,60,25, 25) }.must_raise(Timecode::RangeError)
-    lambda{ Timecode.at(1,0,60,32, 30) }.must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.at(1,0,60,25, 25) }).must_raise(Timecode::RangeError)
+    _(lambda{ Timecode.at(1,0,60,32, 30) }).must_raise(Timecode::RangeError)
   end
 
   it "properly accept usable values" do
-    Timecode.at(20, 20, 10, 5).to_s.must_equal "20:20:10:05"
+    _(Timecode.at(20, 20, 10, 5).to_s).must_equal "20:20:10:05"
   end
 end
 
@@ -128,61 +128,61 @@ describe "An existing Timecode should" do
 
   it "report that the framerates are in delta" do
     tc = Timecode.new(1)
-    tc.framerate_in_delta(25.0000000000000001, 25.0000000000000003).must_equal(true)
+    _(tc.framerate_in_delta(25.0000000000000001, 25.0000000000000003)).must_equal(true)
   end
 
   it "validate equality based on delta" do
     t1, t2 = Timecode.new(10, 25.0000000000000000000000000001), Timecode.new(10, 25.0000000000000000000000000002)
-    t1.must_equal(t2)
+    _(t1).must_equal(t2)
   end
 
   it "report total as it's to_i" do
-    Timecode.new(10).to_i.must_equal(10)
+    _(Timecode.new(10).to_i).must_equal(10)
   end
 
   it "coerce itself to int" do
-    (10 + Timecode.new(2)).must_equal 12
+    _((10 + Timecode.new(2))).must_equal 12
   end
 
   it "support hours" do
-    @five_seconds.must_respond_to :hours
-    @five_seconds.hours.must_equal 0
-    @film_tc.hours.must_equal 1
+    _(@five_seconds).must_respond_to :hours
+    _(@five_seconds.hours).must_equal 0
+    _(@film_tc.hours).must_equal 1
   end
 
   it "support minutes" do
-    @five_seconds.must_respond_to :minutes
-    @five_seconds.minutes.must_equal 0
-    @film_tc.minutes.must_equal 30
+    _(@five_seconds).must_respond_to :minutes
+    _(@five_seconds.minutes).must_equal 0
+    _(@film_tc.minutes).must_equal 30
   end
 
   it "support seconds" do
-    @five_seconds.must_respond_to :seconds
-    @five_seconds.seconds.must_equal 5
-    @film_tc.seconds.must_equal 0
+    _(@five_seconds).must_respond_to :seconds
+    _(@five_seconds.seconds).must_equal 5
+    _(@film_tc.seconds).must_equal 0
   end
 
   it "support frames" do
-    @film_tc.frames.must_equal 0
+    _(@film_tc.frames).must_equal 0
   end
 
   it "report frame_interval as a float" do
     tc = Timecode.new(10)
-    tc.must_respond_to :frame_interval
+    _(tc).must_respond_to :frame_interval
 
-    tc.frame_interval.must_be_within_delta 0.04, 0.0001
+    _(tc.frame_interval).must_be_within_delta 0.04, 0.0001
     tc = Timecode.new(10, 30)
-    tc.frame_interval.must_be_within_delta 0.03333, 0.0001
+    _(tc.frame_interval).must_be_within_delta 0.03333, 0.0001
   end
 
   it "be comparable" do
-    (Timecode.new(10) < Timecode.new(9)).must_equal false
-    (Timecode.new(9) < Timecode.new(10)).must_equal true
-    Timecode.new(9).must_equal Timecode.new(9)
+    _((Timecode.new(10) < Timecode.new(9))).must_equal false
+    _((Timecode.new(9) < Timecode.new(10))).must_equal true
+    _(Timecode.new(9)).must_equal Timecode.new(9)
   end
 
   it "raise on comparison of incompatible timecodes" do
-    lambda { Timecode.new(10, 10) < Timecode.new(10, 20)}.must_raise(Timecode::WrongFramerate)
+    _(lambda { Timecode.new(10, 10) < Timecode.new(10, 20)}).must_raise(Timecode::WrongFramerate)
   end
 end
 
@@ -198,7 +198,7 @@ end
 
 describe "A Timecode of zero should" do
   it "properly respond to zero?" do
-    Timecode.new(0).must_respond_to :zero?
+    _(Timecode.new(0)).must_respond_to :zero?
     # must_be :zero? is somehow broken
     assert Timecode.new(0).zero?
     refute Timecode.new(1).zero?
@@ -210,76 +210,76 @@ describe "Timecode.from_seconds should" do
     float_secs = 89.99165971643036
     float_fps = 23.9898
     Timecode.add_custom_framerate!(float_fps)
-    lambda{ Timecode.from_seconds(float_secs, float_fps) }.must_be_silent
+    _(lambda{ Timecode.from_seconds(float_secs, float_fps) }).must_be_silent
   end
-  
-  it "properly process a DF framerate" do    
-    Timecode.from_seconds(322.4004, 29.97, true).to_i.must_equal 9662
-    Timecode.from_seconds(600.0, 29.97, true).to_i.must_equal 17982
-    Timecode.from_seconds(15603.5005, 29.97, true).to_i.must_equal 467637
-    Timecode.from_seconds(36000.0, 29.97, true).to_i.must_equal 1078920
+
+  it "properly process a DF framerate" do
+    _(Timecode.from_seconds(322.4004, 29.97, true).to_i).must_equal 9662
+    _(Timecode.from_seconds(600.0, 29.97, true).to_i).must_equal 17982
+    _(Timecode.from_seconds(15603.5005, 29.97, true).to_i).must_equal 467637
+    _(Timecode.from_seconds(36000.0, 29.97, true).to_i).must_equal 1078920
   end
 end
 
 describe "Timecode#to_seconds should" do
   it "return a float" do
-    Timecode.new(0).to_seconds.must_be_kind_of Float
+    _(Timecode.new(0).to_seconds).must_be_kind_of Float
   end
 
   it "return the value in seconds" do
     fps = 24
     secs = 126.3
-    Timecode.new(fps * secs, fps).to_seconds.must_be_within_delta 126.3, 0.1    
+    _(Timecode.new(fps * secs, fps).to_seconds).must_be_within_delta 126.3, 0.1
   end
 
   it "properly roundtrip a value via Timecode.from_seconds" do
     secs_in = 19.76
     from_secs = Timecode.from_seconds(secs_in, 25.0)
-    from_secs.total.must_equal 494
-    from_secs.to_seconds.must_be_within_delta secs_in, 0.001
-    
+    _(from_secs.total).must_equal 494
+    _(from_secs.to_seconds).must_be_within_delta secs_in, 0.001
+
     secs_in = 15603.50
     from_secs = Timecode.from_seconds(secs_in, 29.97, true)
-    from_secs.total.must_equal 467637
-    from_secs.to_seconds.must_be_within_delta secs_in, 0.005
+    _(from_secs.total).must_equal 467637
+    _(from_secs.to_seconds).must_be_within_delta secs_in, 0.005
   end
 end
 
 describe "An existing Timecode on inspection should" do
   it "properly present himself via inspect" do
-    Timecode.new(10, 25).inspect.must_equal "#<Timecode:00:00:00:10 (10F@25.00)>"
-    Timecode.new(10, 12).inspect.must_equal "#<Timecode:00:00:00:10 (10F@12.00)>"
+    _(Timecode.new(10, 25).inspect).must_equal "#<Timecode:00:00:00:10 (10F@25.00)>"
+    _(Timecode.new(10, 12).inspect).must_equal "#<Timecode:00:00:00:10 (10F@12.00)>"
   end
 
   it "properly print itself" do
-    Timecode.new(5, 25).to_s.must_equal "00:00:00:05"
+    _(Timecode.new(5, 25).to_s).must_equal "00:00:00:05"
   end
-  
+
   it "properly print itself with DF" do
-    Timecode.new(9662, 29.97, true).to_s.must_equal "00:05:22;12"
-    Timecode.new(9662, 29.97, false).to_s.must_equal "00:05:22:02"
+    _(Timecode.new(9662, 29.97, true).to_s).must_equal "00:05:22;12"
+    _(Timecode.new(9662, 29.97, false).to_s).must_equal "00:05:22:02"
   end
 end
 
 describe "An existing Timecode compared by adjacency" do
   it "properly detect an adjacent timecode to the left" do
-    Timecode.new(10).must_be :adjacent_to?, Timecode.new(9)
-    Timecode.new(10).wont_be :adjacent_to?, Timecode.new(8)
+    _(Timecode.new(10)).must_be :adjacent_to?, Timecode.new(9)
+    _(Timecode.new(10)).wont_be :adjacent_to?, Timecode.new(8)
   end
-  
+
   it "properly detect an adjacent DF timecode to the left" do
-    Timecode.new(1800, 29.97, true).must_be :adjacent_to?, Timecode.new(1799, 29.97, true)
-    Timecode.new(1800, 29.97, true).wont_be :adjacent_to?, Timecode.new(1798, 29.97, true)
+    _(Timecode.new(1800, 29.97, true)).must_be :adjacent_to?, Timecode.new(1799, 29.97, true)
+    _(Timecode.new(1800, 29.97, true)).wont_be :adjacent_to?, Timecode.new(1798, 29.97, true)
   end
 
   it "properly detect an adjacent timecode to the right" do
-    Timecode.new(10).must_be :adjacent_to?, Timecode.new(11)
-    Timecode.new(10).wont_be :adjacent_to?, Timecode.new(12)
+    _(Timecode.new(10)).must_be :adjacent_to?, Timecode.new(11)
+    _(Timecode.new(10)).wont_be :adjacent_to?, Timecode.new(12)
   end
-  
+
   it "properly detect an adjacent DF timecode to the right" do
-    Timecode.new(1799, 29.97, true).must_be :adjacent_to?, Timecode.new(1800, 29.97, true)
-    Timecode.new(1799, 29.97, true).wont_be :adjacent_to?, Timecode.new(1801, 29.97, true)
+    _(Timecode.new(1799, 29.97, true)).must_be :adjacent_to?, Timecode.new(1800, 29.97, true)
+    _(Timecode.new(1799, 29.97, true)).wont_be :adjacent_to?, Timecode.new(1801, 29.97, true)
   end
 end
 
@@ -287,35 +287,35 @@ describe "A Timecode on conversion should" do
   it "copy itself with a different framerate" do
     tc = Timecode.new(1800, 25)
     at24 = tc.convert(24)
-    at24.total.must_equal 1800
+    _(at24.total).must_equal 1800
     at29 = tc.convert(29.97)
-    at29.total.must_equal 1800
-    at29.to_s.must_equal "00:01:00:00"
+    _(at29.total).must_equal 1800
+    _(at29.to_s).must_equal "00:01:00:00"
     at29DF = tc.convert(29.97, true)
-    at29DF.total.must_equal 1800
-    at29DF.to_s.must_equal "00:01:00;02"
-    
+    _(at29DF.total).must_equal 1800
+    _(at29DF.to_s).must_equal "00:01:00;02"
+
     tc1 = Timecode.new(1800, 23.976, true)
     at29 = tc1.convert(29.97)
-    at29.total.must_equal 1800
-    at29.to_s.must_equal "00:01:00;02"
+    _(at29.total).must_equal 1800
+    _(at29.to_s).must_equal "00:01:00;02"
     at29ND = tc1.convert(29.97, false)
-    at29ND.total.must_equal 1800
-    at29ND.to_s.must_equal "00:01:00:00"
+    _(at29ND.total).must_equal 1800
+    _(at29ND.to_s).must_equal "00:01:00:00"
   end
 end
 
 describe "An existing Timecode used within ranges should" do
   it "properly provide successive value that is one frame up" do
-    Timecode.new(10).succ.total.must_equal 11
-    Timecode.new(22, 45).succ.must_equal Timecode.new(23, 45)
-    Timecode.new(1799, 29.97, true).succ.must_equal Timecode.new(1800, 29.97, true)
+    _(Timecode.new(10).succ.total).must_equal 11
+    _(Timecode.new(22, 45).succ).must_equal Timecode.new(23, 45)
+    _(Timecode.new(1799, 29.97, true).succ).must_equal Timecode.new(1800, 29.97, true)
   end
 
   it "work as a range member" do
     r = Timecode.new(10)...Timecode.new(20)
-    r.to_a.length.must_equal 10
-    r.to_a[4].must_equal Timecode.new(14)
+    _(r.to_a.length).must_equal 10
+    _(r.to_a[4]).must_equal Timecode.new(14)
   end
 
 end
@@ -324,82 +324,82 @@ describe "A Timecode on calculations should" do
 
   it "support addition" do
     a, b = Timecode.new(24, 25.000000000000001), Timecode.new(22, 25.000000000000002)
-    (a + b).must_equal Timecode.new(24 + 22, 25.000000000000001)
+    _((a + b)).must_equal Timecode.new(24 + 22, 25.000000000000001)
   end
 
   it "should raise on addition if framerates do not match" do
-    lambda{ Timecode.new(10, 25) + Timecode.new(10, 30) }.must_raise(Timecode::WrongFramerate)
+    _(lambda{ Timecode.new(10, 25) + Timecode.new(10, 30) }).must_raise(Timecode::WrongFramerate)
   end
-  
+
   it "should raise on addition if drop flag mismatches" do
-    lambda{ Timecode.new(10, 29.97, true) + Timecode.new(10, 29.97) }.must_raise(Timecode::WrongDropFlag)
+    _(lambda{ Timecode.new(10, 29.97, true) + Timecode.new(10, 29.97) }).must_raise(Timecode::WrongDropFlag)
   end
 
   it "when added with an integer instead calculate on total" do
-    (Timecode.new(5) + 5).must_equal(Timecode.new(10))
+    _((Timecode.new(5) + 5)).must_equal(Timecode.new(10))
   end
-  
+
   it "when adding DF flag is preserved" do
     a, b = Timecode.new(24, 29.97, true), Timecode.new(22, 29.97, true)
     c, d = Timecode.new(24, 29.97), Timecode.new(22, 29.97)
     tcsum = a + b
-    tcsum.must_equal Timecode.new(24 + 22, 29.97, true)
-    tcsum.drop?.must_equal true
-    (c + d).drop?.must_equal false
+    _(tcsum).must_equal Timecode.new(24 + 22, 29.97, true)
+    _(tcsum.drop?).must_equal true
+    _((c + d).drop?).must_equal false
   end
 
   it "support subtraction" do
     a, b = Timecode.new(10), Timecode.new(4)
-    (a - b).must_equal Timecode.new(6)
+    _((a - b)).must_equal Timecode.new(6)
   end
 
   it "on subtraction of an integer instead calculate on total" do
-    (Timecode.new(15) - 5).must_equal Timecode.new(10)
+    _((Timecode.new(15) - 5)).must_equal Timecode.new(10)
   end
 
   it "raise when subtracting a Timecode with a different framerate" do
-    lambda { Timecode.new(10, 25) - Timecode.new(10, 30) }.must_raise(Timecode::WrongFramerate)
+    _(lambda { Timecode.new(10, 25) - Timecode.new(10, 30) }).must_raise(Timecode::WrongFramerate)
   end
-  
+
   it "raise when subtracting a Timecode with a different drop frame flag" do
-    lambda { Timecode.new(10, 29.97, true) - Timecode.new(10, 29.97) }.must_raise(Timecode::WrongDropFlag)
+    _(lambda { Timecode.new(10, 29.97, true) - Timecode.new(10, 29.97) }).must_raise(Timecode::WrongDropFlag)
   end
-  
+
   it "when subtracting DF flag is preserved" do
     a, b = Timecode.new(24, 29.97, true), Timecode.new(22, 29.97, true)
     c, d = Timecode.new(24, 29.97), Timecode.new(22, 29.97)
     tcsub = a - b
-    tcsub.must_equal Timecode.new(24 - 22, 29.97, true)
-    tcsub.drop?.must_equal true
-    (c - d).drop?.must_equal false
+    _(tcsub).must_equal Timecode.new(24 - 22, 29.97, true)
+    _(tcsub.drop?).must_equal true
+    _((c - d).drop?).must_equal false
   end
 
   it "support multiplication" do
-    (Timecode.new(10) * 10).must_equal(Timecode.new(100))
+    _((Timecode.new(10) * 10)).must_equal(Timecode.new(100))
   end
 
   it "raise when the resultig Timecode is negative" do
-    lambda { Timecode.new(10) * -200 }.must_raise(Timecode::RangeError)
+    _(lambda { Timecode.new(10) * -200 }).must_raise(Timecode::RangeError)
   end
-  
+
   it "preserves drop frame flag when multiplying" do
-    (Timecode.new(10, 29.97, true) * 10).drop?.must_equal true
+    _((Timecode.new(10, 29.97, true) * 10).drop?).must_equal true
   end
 
   it "return a Timecode when divided by an Integer" do
     v = Timecode.new(200) / 20
-    v.must_be_kind_of(Timecode)
-    v.must_equal Timecode.new(10)
+    _(v).must_be_kind_of(Timecode)
+    _(v).must_equal Timecode.new(10)
   end
 
   it "return a number when divided by another Timecode" do
     v = Timecode.new(200) / Timecode.new(20)
-    v.must_be_kind_of(Numeric)
-    v.must_equal 10
+    _(v).must_be_kind_of(Numeric)
+    _(v).must_equal 10
   end
-  
+
   it "preserves drop frame flag when dividing" do
-    (Timecode.new(200, 29.97, true) / 20).drop?.must_equal true
+    _((Timecode.new(200, 29.97, true) / 20).drop?).must_equal true
   end
 end
 
@@ -407,25 +407,25 @@ describe "A Timecode used with fractional number of seconds" do
 
   it "should properly return fractional seconds" do
     tc = Timecode.new(100 - 1, fps = 25)
-    tc.frames.must_equal 24
+    _(tc.frames).must_equal 24
 
-    tc.with_frames_as_fraction.must_equal "00:00:03.96"
-    tc.with_fractional_seconds.must_equal "00:00:03.96"
-    tc.with_srt_fraction.must_equal "00:00:03,96"
+    _(tc.with_frames_as_fraction).must_equal "00:00:03.96"
+    _(tc.with_fractional_seconds).must_equal "00:00:03.96"
+    _(tc.with_srt_fraction).must_equal "00:00:03,96"
   end
 
   it "properly translate to frames when instantiated from fractional seconds" do
     fraction = 7.1
     tc = Timecode.from_seconds(fraction, 10)
-    tc.to_s.must_equal "00:00:07:01"
+    _(tc.to_s).must_equal "00:00:07:01"
 
     fraction = 7.5
     tc = Timecode.from_seconds(fraction, 10)
-    tc.to_s.must_equal "00:00:07:05"
+    _(tc.to_s).must_equal "00:00:07:05"
 
     fraction = 7.16
     tc = Timecode.from_seconds(fraction, 25)
-    tc.to_s.must_equal "00:00:07:04"
+    _(tc.to_s).must_equal "00:00:07:04"
   end
 
 end
@@ -434,25 +434,25 @@ describe "A custom Timecode descendant should" do
   class CustomTC < Timecode; end
 
   it "properly classify on parse" do
-    CustomTC.parse("001").must_be_kind_of CustomTC
+    _(CustomTC.parse("001")).must_be_kind_of CustomTC
   end
 
   it "properly classify on at" do
-    CustomTC.at(10,10,10,10).must_be_kind_of CustomTC
+    _(CustomTC.at(10,10,10,10)).must_be_kind_of CustomTC
   end
 
   it "properly  classify on calculations" do
     computed = CustomTC.parse("10h") + Timecode.new(10)
-    computed.must_be_kind_of CustomTC
+    _(computed).must_be_kind_of CustomTC
 
     computed = CustomTC.parse("10h") - Timecode.new(10)
-    computed.must_be_kind_of CustomTC
+    _(computed).must_be_kind_of CustomTC
 
     computed = CustomTC.parse("10h") * 5
-    computed.must_be_kind_of CustomTC
+    _(computed).must_be_kind_of CustomTC
 
     computed = CustomTC.parse("10h") / 5
-    computed.must_be_kind_of CustomTC
+    _(computed).must_be_kind_of CustomTC
   end
 
 end
@@ -460,19 +460,19 @@ end
 describe "Timecode.from_filename_in_sequence should" do
   it "detect the timecode" do
     tc = Timecode.from_filename_in_sequence("foobar.0000012.jpg", fps = 25)
-    tc.must_equal(Timecode.new(12, 25))
+    _(tc).must_equal(Timecode.new(12, 25))
   end
 end
 
 describe 'Timecode with hours larger than 99 should' do
   it 'print itself without rollover' do
     tc = Timecode.at(129,34,42,5)
-    tc.to_s_without_rollover.must_equal '129:34:42:05'
+    _(tc.to_s_without_rollover).must_equal '129:34:42:05'
   end
-  
+
   it 'print itself with rollover when using to_smpte' do
     tc = Timecode.at(129,34,42,5)
-    tc.to_s.must_equal '29:34:42:05'
+    _(tc.to_s).must_equal '29:34:42:05'
   end
 end
 
@@ -480,53 +480,51 @@ describe "Timecode.parse should" do
 
   it "handle complete SMPTE timecode" do
     simple_tc = "00:10:34:10"
-    Timecode.parse(simple_tc).to_s.must_equal(simple_tc)
+    _(Timecode.parse(simple_tc).to_s).must_equal(simple_tc)
   end
-  
+
   it "handle complete SMPTE timecode with drop frame flag" do
     simple_tc = "00:10:34;10"
     tc = Timecode.parse(simple_tc, 29.97)
-    tc.to_s.must_equal(simple_tc)
-    tc.drop?.must_equal true
+    _(tc.to_s).must_equal(simple_tc)
+    _(tc.drop?).must_equal true
   end
 
   it "handle complete SMPTE timecode with plus for 24 frames per second" do
     simple_tc = "00:10:34+10"
     p = Timecode.parse(simple_tc)
-    p.to_s.must_equal("00:10:34:10")
-    p.fps.must_equal 24
+    _(p.to_s).must_equal("00:10:34:10")
+    _(p.fps).must_equal 24
   end
 
   it "handle timecode with fractional seconds" do
     tc = Timecode.parse("10:10:10.2", 25)
-    tc.to_s.must_equal "10:10:10:05"
+    _(tc.to_s).must_equal "10:10:10:05"
 
     tc = Timecode.parse("10:10:10,200", 25)
-    tc.to_s.must_equal "10:10:10:05"
+    _(tc.to_s).must_equal "10:10:10:05"
   end
 
   it "handle timecode with fractional seconds (euro style, SRT)" do
     tc = Timecode.parse("10:10:10,200", 25)
-    tc.to_s.must_equal "10:10:10:05"
+    _(tc.to_s).must_equal "10:10:10:05"
   end
 
   it "handle timecode with ticks" do
     tc = Timecode.parse("10:10:10:103", 25)
-    tc.to_s.must_equal "10:10:10:10"
+    _(tc.to_s).must_equal "10:10:10:10"
 
     tc = Timecode.parse("10:10:10:249", 25)
-    tc.to_s.must_equal "10:10:10:24"
+    _(tc.to_s).must_equal "10:10:10:24"
   end
 
   it "raise when there are more than 249 ticks" do
-    lambda {
-      tc = Timecode.parse("10:10:10:250", 25)
-    }.must_raise(Timecode::RangeError)
+    _(lambda { Timecode.parse("10:10:10:250", 25) }).must_raise(Timecode::RangeError)
   end
 
   it "handle timecode with fractional seconds with spaces at start and end" do
     tc = Timecode.parse(" 00:00:01.040 ")
-    tc.to_s.must_equal "00:00:01:01"
+    _(tc.to_s).must_equal "00:00:01:01"
   end
 
 # I am commenting this one out for now, these were present in some odd subtitle file.
@@ -537,100 +535,100 @@ describe "Timecode.parse should" do
 # end
 
   it "parse a row of numbers as parts of a timecode starting from the right" do
-    Timecode.parse("10").must_equal Timecode.new(10)
-    Timecode.parse("210").must_equal Timecode.new(60)
-    Timecode.parse("10101010").to_s.must_equal "10:10:10:10"
+    _(Timecode.parse("10")).must_equal Timecode.new(10)
+    _(Timecode.parse("210")).must_equal Timecode.new(60)
+    _(Timecode.parse("10101010").to_s).must_equal "10:10:10:10"
   end
 
   it "parse a number with f suffix as frames" do
-    Timecode.parse("60f").must_equal Timecode.new(60)
+    _(Timecode.parse("60f")).must_equal Timecode.new(60)
   end
 
   it "parse a number with s suffix as seconds" do
-    Timecode.parse("2s", 25).must_equal Timecode.new(50, 25)
-    Timecode.parse("2s", 30).must_equal Timecode.new(60, 30)
+    _(Timecode.parse("2s", 25)).must_equal Timecode.new(50, 25)
+    _(Timecode.parse("2s", 30)).must_equal Timecode.new(60, 30)
   end
 
   it "parse a number with m suffix as minutes" do
-    Timecode.parse("3m").must_equal Timecode.new(25 * 60 * 3)
+    _(Timecode.parse("3m")).must_equal Timecode.new(25 * 60 * 3)
   end
 
   it "parse a number with h suffix as hours" do
-    Timecode.parse("3h").must_equal Timecode.new(25 * 60 * 60 * 3)
+    _(Timecode.parse("3h")).must_equal Timecode.new(25 * 60 * 60 * 3)
   end
 
   it "parse different suffixes as a sum of elements" do
-    Timecode.parse("1h 4f").to_s.must_equal '01:00:00:04'
-    Timecode.parse("4f 1h").to_s.must_equal '01:00:00:04'
-    Timecode.parse("29f 1h").to_s.must_equal '01:00:01:04'
-    Timecode.parse("29f \n\n\n\n\n\    1h").to_s.must_equal '01:00:01:04'
+    _(Timecode.parse("1h 4f").to_s).must_equal '01:00:00:04'
+    _(Timecode.parse("4f 1h").to_s).must_equal '01:00:00:04'
+    _(Timecode.parse("29f 1h").to_s).must_equal '01:00:01:04'
+    _(Timecode.parse("29f \n\n\n\n\n\    1h").to_s).must_equal '01:00:01:04'
   end
 
   it "parse a number of digits as timecode" do
-    Timecode.parse("00000001").to_s.must_equal "00:00:00:01"
-    Timecode.parse("1").to_s.must_equal "00:00:00:01"
-    Timecode.parse("10").to_s.must_equal "00:00:00:10"
+    _(Timecode.parse("00000001").to_s).must_equal "00:00:00:01"
+    _(Timecode.parse("1").to_s).must_equal "00:00:00:01"
+    _(Timecode.parse("10").to_s).must_equal "00:00:00:10"
   end
 
   it "truncate a large number to the parseable length" do
-    Timecode.parse("1000000000000000001").to_s.must_equal "10:00:00:00"
+    _(Timecode.parse("1000000000000000001").to_s).must_equal "10:00:00:00"
   end
 
   it "left-pad a large number to give proper TC" do
-    Timecode.parse("123456", 57).to_s.must_equal "00:12:34:56"
+    _(Timecode.parse("123456", 57).to_s).must_equal "00:12:34:56"
   end
 
   it "parse timecode with fractional second instead of frames" do
     fraction = "00:00:07.1"
     tc = Timecode.parse_with_fractional_seconds(fraction, 10)
-    tc.to_s.must_equal "00:00:07:01"
+    _(tc.to_s).must_equal "00:00:07:01"
 
     fraction = "00:00:07.5"
     tc = Timecode.parse_with_fractional_seconds(fraction, 10)
-    tc.to_s.must_equal "00:00:07:05"
+    _(tc.to_s).must_equal "00:00:07:05"
 
     fraction = "00:00:07.04"
     tc = Timecode.parse_with_fractional_seconds(fraction, 12.5)
-    tc.to_s.must_equal "00:00:07:00"
+    _(tc.to_s).must_equal "00:00:07:00"
 
     fraction = "00:00:07.16"
     tc = Timecode.parse_with_fractional_seconds(fraction, 12.5)
-    tc.to_s.must_equal "00:00:07:02"
+    _(tc.to_s).must_equal "00:00:07:02"
   end
 
   it "reports DF timecode" do
     df_tc = "00:00:00;01"
-    Timecode.parse(df_tc, 29.97).drop?.must_equal true
+    _(Timecode.parse(df_tc, 29.97).drop?).must_equal true
   end
 
   it "raise on improper format" do
-    lambda { Timecode.parse("Meaningless nonsense", 25) }.must_raise Timecode::CannotParse
-    lambda { Timecode.parse("", 25) }.must_raise Timecode::CannotParse
+    _(lambda { Timecode.parse("Meaningless nonsense", 25) }).must_raise Timecode::CannotParse
+    _(lambda { Timecode.parse("", 25) }).must_raise Timecode::CannotParse
   end
 
   it "raise on empty argument" do
-    lambda { Timecode.parse("   \n\n  ", 25) }.must_raise Timecode::CannotParse
+    _(lambda { Timecode.parse("   \n\n  ", 25) }).must_raise Timecode::CannotParse
   end
 
   it "properly handle 09 and 08 as part of complete TC pattern" do
-    Timecode.parse( "09:08:09:08", 25).total.must_equal 822233
+    _(Timecode.parse( "09:08:09:08", 25).total).must_equal 822233
   end
 
   it "properly handle 10 minute DF timecode" do
-    Timecode.parse( "00:10:00;00", 29.97).total.must_equal 17982
+    _(Timecode.parse( "00:10:00;00", 29.97).total).must_equal 17982
   end
 end
 
 describe "Timecode.soft_parse should" do
   it "parse the timecode" do
-    Timecode.soft_parse('200').to_s.must_equal "00:00:02:00"
+    _(Timecode.soft_parse('200').to_s).must_equal "00:00:02:00"
   end
 
   it "not raise on improper format and return zero TC instead" do
-    lambda do
+    _(lambda do
       tc = Timecode.soft_parse("Meaningless nonsense", 25)
-      tc.must_equal Timecode.new(0)
-    end.must_be_silent
+      _(tc).must_equal Timecode.new(0)
+    end).must_be_silent
   end
 end
 
@@ -638,8 +636,8 @@ describe 'Timecode#to_s' do
   it 'formats 25 and 25 FPS timecodes uniformly' do
     at25 = Timecode.parse("1h", 25)
     at24 = Timecode.parse("1h", 24)
-    at25.to_s.must_equal "01:00:00:00"
-    at24.to_s.must_equal "01:00:00:00"
+    _(at25.to_s).must_equal "01:00:00:00"
+    _(at24.to_s).must_equal "01:00:00:00"
   end
 end
 
@@ -647,8 +645,8 @@ describe 'Timecode#inspect' do
   it 'formats 25 and 25 FPS timecodes differently' do
     at25 = Timecode.parse("1h", 25)
     at24 = Timecode.parse("1h", 24)
-    at25.inspect.must_equal "#<Timecode:01:00:00:00 (90000F@25.00)>"
-    at24.inspect.must_equal "#<Timecode:01:00:00+00 (86400F@24.00)>"
+    _(at25.inspect).must_equal "#<Timecode:01:00:00:00 (90000F@25.00)>"
+    _(at24.inspect).must_equal "#<Timecode:01:00:00+00 (86400F@24.00)>"
   end
 end
 
@@ -656,11 +654,11 @@ describe "Timecode with unsigned integer conversions should" do
 
   it "parse from a 4x4bits packed 32bit unsigned int" do
     uint, tc = 87310853, Timecode.at(5,34,42,5)
-    Timecode.from_uint(uint).must_equal tc
+    _(Timecode.from_uint(uint)).must_equal tc
   end
 
   it "properly convert itself back to 4x4 bits 32bit unsigned int" do
     uint, tc = 87310853, Timecode.at(5,34,42,5)
-    tc.to_uint.must_equal uint
+    _(tc.to_uint).must_equal uint
   end
 end

--- a/test/test_timecode.rb
+++ b/test/test_timecode.rb
@@ -617,6 +617,15 @@ describe "Timecode.parse should" do
   it "properly handle 10 minute DF timecode" do
     _(Timecode.parse( "00:10:00;00", 29.97).total).must_equal 17982
   end
+
+  it "handle non integer fps without being accurate" do
+    _(Timecode.parse( "15:25:13:01", 24000.0/1001.0).total).must_equal 1332313
+  end
+
+  it "properly handle non integer fps" do
+    skip "non integer fps aren't not handled properly - this test fails whereas it should pass"
+    _(Timecode.parse( "15:25:13:01", 24000.0/1001.0).total).must_be_within_delta 1330982, 0.02
+  end
 end
 
 describe "Timecode.soft_parse should" do


### PR DESCRIPTION
This fix can be considered as being a breaking change since the results
will be different and that could impact consumers of this library.

The changes were done only for the case where there is no dropped frame.
`allow_inaccurate` was added to `parse_with_fractional_seconds`,
`parse_with_ticks` and `parse` with the default value `value` so those 2
last functions (not `parse`) are backward compatible.

Also fixed the examples shared in the documentation. Even before the
changes of this commit, the 2nd example was wrong. The issues were
```
You are calculating timecodes with different drop flag values (Timecode::WrongDropFlag)
You are calculating timecodes with different framerates (Timecode::WrongFramerate)
```
